### PR TITLE
Iris Fixes

### DIFF
--- a/bootstrap/src/main/java/io/github/coolcrabs/brachyura/bootstrap/Main.java
+++ b/bootstrap/src/main/java/io/github/coolcrabs/brachyura/bootstrap/Main.java
@@ -46,10 +46,10 @@ public class Main {
             String line = null;
             while ((line = confReader.readLine()) != null) {
                 String[] a = line.split("\t");
-                URL url = new URL(a[0]);
-                String hash = a[1];
-                String fileName = a[2];
-                boolean isjar = Boolean.parseBoolean(a[3]);
+                URL url = new URL(a[0].trim());
+                String hash = a[1].trim();
+                String fileName = a[2].trim();
+                boolean isjar = Boolean.parseBoolean(a[3].trim());
                 Path download = getDownload(url, hash, fileName);
                 if (isjar) classpath.add(download);
             }

--- a/brachyura-mixin-compile-extensions/pom.xml
+++ b/brachyura-mixin-compile-extensions/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.coolcrabs</groupId>
     <artifactId>brachyura-mixin-compile-extensions</artifactId>
-    <version>0.4</version>
+    <version>0.5</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/brachyura-mixin-compile-extensions/src/main/java/io/github/coolcrabs/brachyura/mixin/BrachyuraMappingProvider.java
+++ b/brachyura-mixin-compile-extensions/src/main/java/io/github/coolcrabs/brachyura/mixin/BrachyuraMappingProvider.java
@@ -63,7 +63,7 @@ class BrachyuraMappingProvider implements IMappingProvider {
             if (method.getDesc().equals(newdesc)) {
                 return null;
             } else {
-                return new MappingMethod(method.getOwner(), method.getName(), newdesc);
+                return new MappingMethod(method.getOwner(), method.getSimpleName(), newdesc);
             }
         } else { // MC Class
             TinyMethod method2 = getMethod(method.getOwner(), method.getSimpleName(), method.getDesc());

--- a/brachyura/pom.xml
+++ b/brachyura/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>io.github.coolcrabs</groupId>
             <artifactId>brachyura-mixin-compile-extensions</artifactId>
-            <version>0.4</version>
+            <version>0.5</version>
         </dependency>
         <dependency>
             <groupId>io.github.coolcrabs</groupId>

--- a/brachyura/pom.xml
+++ b/brachyura/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.coolcrabs</groupId>
     <artifactId>brachyura</artifactId>
-    <version>0.55</version>
+    <version>0.56</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/brachyura/pom.xml
+++ b/brachyura/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.coolcrabs</groupId>
     <artifactId>brachyura</artifactId>
-    <version>0.56</version>
+    <version>0.57</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/decompiler/cfr/BrachyuraCfrClassFileSource.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/decompiler/cfr/BrachyuraCfrClassFileSource.java
@@ -122,6 +122,11 @@ class BrachyuraCfrClassFileSource implements ClassFileSource, Closeable {
 
     @Override
     public Pair<byte[], String> getClassFileContent(String path) throws IOException {
+        if ("byte.class".equals(path)) {
+            // Suppress "WARN: Unable to find byte.class"
+            return new Pair<>(null, path);
+        }
+
         byte[] content = classmap.computeIfAbsent(path, p -> {
             try {
                 Path path2 = allClasses.get(path);

--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Intellijank.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Intellijank.java
@@ -49,7 +49,27 @@ public enum Intellijank implements Ide {
     public void updateProject(Path projectDir, IdeProject ideProject, @Nullable BaseJavaProject buildscript) {
         try {
             Path ideaPath = projectDir.resolve(".idea");
-            if (Files.exists(ideaPath)) PathUtil.deleteDirectory(ideaPath);
+
+            if (Files.exists(ideaPath)) {
+                // Delete unimportant files from .idea
+                Files.list(ideaPath).forEach(path -> {
+                    if (Files.isDirectory(path)) {
+                        // delete subdirectories
+                        PathUtil.deleteDirectory(path);
+                    } else if ("vcs.xml".equals(path.getFileName().toString())) {
+                        // do not delete vcs.xml, as it is important
+                        // otherwise we'll reset people's Git configurations
+                    } else {
+                        // delete other files
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            Util.sneak(e);
+                        }
+                    }
+                });
+            }
+
             Files.walkFileTree(projectDir, Collections.emptySet(), 1, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {

--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/processing/ProcessorChain.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/processing/ProcessorChain.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.function.Supplier;
 
+import io.github.coolcrabs.brachyura.util.ArrayUtil;
 import io.github.coolcrabs.brachyura.util.Util;
 import java.util.Arrays;
 
@@ -14,7 +15,11 @@ public class ProcessorChain {
     public ProcessorChain(Processor...processors) {
         this.processors = processors;
     }
-    
+
+    public ProcessorChain(ProcessorChain existing, Processor...processors) {
+        this.processors = ArrayUtil.join(Processor.class, existing.processors, processors);
+    }
+
     public void apply(ProcessingSink out, ProcessingSource... in) {
         apply(out, Arrays.asList(in));
     }
@@ -36,6 +41,10 @@ public class ProcessorChain {
         } catch (IOException e) {
             Util.sneak(e);
         }
+    }
+
+    public Processor[] getProcessors() {
+        return Arrays.copyOf(processors, processors.length);
     }
 
     static class Collector implements ProcessingSink {

--- a/build/src/main/java/io/github/coolcrabs/brachyura/build/Main.java
+++ b/build/src/main/java/io/github/coolcrabs/brachyura/build/Main.java
@@ -56,6 +56,8 @@ public class Main {
     static boolean github = Boolean.parseBoolean(System.getenv("CI"));
     static String commit = github ? getCommitHash() : null;
     static final String GITHUB_TOKEN = System.getenv("GITHUB_TOKEN");
+    static final String GITHUB_REPOSITORY =
+            System.getenv("GITHUB_REPOSITORY") != null ? System.getenv("GITHUB_REPOSITORY") : "CoolCrabs/brachyura";
     static GitHub gitHub2;
 
     public static void main(String[] args) throws Exception {
@@ -116,7 +118,7 @@ public class Main {
     }
 
     static void uploadGithub(Path outDir) throws Exception {
-        GHRepository repo = gitHub2.getRepository("CoolCrabs/brachyura");
+        GHRepository repo = gitHub2.getRepository(GITHUB_REPOSITORY);
         System.out.println("Creating tag " + commit);
         GHTagObject tag = repo.createTag("v_" + commit, commit, commit, "commit");
         GHRelease release = repo.createRelease(tag.getTag()).commitish(commit).create();
@@ -144,7 +146,7 @@ public class Main {
             Files.copy(is, target);
         }
         String hash = toHexHash(md.digest());
-        return "https://github.com/CoolCrabs/brachyura/releases/download/" + "v_" + commit + "/" + target.getFileName().toString() + "\t" + hash + "\t" + target.getFileName().toString() + "\t" + isJar + "\n";
+        return "https://github.com/" + GITHUB_REPOSITORY + "/releases/download/" + "v_" + commit + "/" + target.getFileName().toString() + "\t" + hash + "\t" + target.getFileName().toString() + "\t" + isJar + "\n";
     }
 
     static void deleteDirectory(Path dir) throws IOException {


### PR DESCRIPTION
- Bumps `brachyura` to 0.57
- Bumps `brachyura-mixin-compile-extensions` to 0.5
- Fixes https://github.com/CoolCrabs/brachyura/issues/12
- Fixes https://github.com/CoolCrabs/brachyura/issues/11
- Fixes https://github.com/CoolCrabs/brachyura/issues/13
- Hacky fix to suppress "WARN: Unable to find byte.class"
- Makes the autorelease setup automatically work on forked repositories
- Fixes a critical method remapping bug in brachyura-mixin-compile-extensions