### PR TITLE
Improve Eclipse support

### DIFF
--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/IdeProject.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/IdeProject.java
@@ -1,11 +1,10 @@
 package io.github.coolcrabs.brachyura.ide;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import io.github.coolcrabs.brachyura.dependency.JavaJarDependency;
 import io.github.coolcrabs.brachyura.util.Lazy;
@@ -17,11 +16,11 @@ public final class IdeProject {
     public final String name;
     public final Lazy<List<JavaJarDependency>> dependencies;
     public final List<RunConfig> runConfigs;
-    public final Map<String, Path> sourcePaths;
+    public final List<Path> sourcePaths;
     public final List<Path> resourcePaths;
     public final int javaVersion;
 
-    IdeProject(String name, Supplier<List<JavaJarDependency>> dependencies, List<RunConfig> runConfigs, Map<String, Path> sourcePaths, List<Path> resourcePaths, int javaVersion) {
+    IdeProject(String name, Supplier<List<JavaJarDependency>> dependencies, List<RunConfig> runConfigs, List<Path> sourcePaths, List<Path> resourcePaths, int javaVersion) {
         this.name = name;
         this.dependencies = new Lazy<>(dependencies);
         this.runConfigs = runConfigs;
@@ -34,7 +33,7 @@ public final class IdeProject {
         private String name = "BrachyuraProject";
         private Supplier<List<JavaJarDependency>> dependencies = Collections::emptyList;
         private List<RunConfig> runConfigs = Collections.emptyList();
-        private Map<String, Path> sourcePaths = Collections.emptyMap();
+        private List<Path> sourcePaths = Collections.emptyList();
         private List<Path> resourcePaths = Collections.emptyList();
         private int javaVersion = 8;
         
@@ -68,14 +67,14 @@ public final class IdeProject {
             return this;
         }
 
-        public IdeProjectBuilder sourcePaths(Map<String, Path> sourcePaths) {
+        public IdeProjectBuilder sourcePaths(List<Path> sourcePaths) {
             this.sourcePaths = sourcePaths;
             return this;
         }
 
         public IdeProjectBuilder sourcePath(Path sourcePath) {
-            this.sourcePaths = new HashMap<>();
-            sourcePaths.put("src", sourcePath);
+            this.sourcePaths = new ArrayList<>();
+            sourcePaths.add(sourcePath);
             return this;
         }
 

--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Intellijank.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Intellijank.java
@@ -155,7 +155,7 @@ public enum Intellijank implements Ide {
                     w.writeStartElement("content");
                     w.writeAttribute("url", "file://$MODULE_DIR$");
                     w.indent();
-                        for (Path sourceDir : ideProject.sourcePaths.values()) {
+                        for (Path sourceDir : ideProject.sourcePaths) {
                             w.newline();
                             w.writeEmptyElement("sourceFolder");
                             w.writeAttribute("url", sourceDir.toUri().toASCIIString());

--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Netbeans.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Netbeans.java
@@ -59,7 +59,7 @@ public enum Netbeans implements Ide {
         NetbeansProject(Path dir, IdeProject ideProject) {
             if (ideProject.sourcePaths.size() != 1) throw new UnsupportedOperationException("Netbeans support for >1 source path not impl");
             projectProperties.setProperty("application.title", ideProject.name);
-            projectProperties.setProperty("src.dir", ideProject.sourcePaths.values().iterator().next().toString());
+            projectProperties.setProperty("src.dir", ideProject.sourcePaths.iterator().next().toString());
             StringBuilder javacClasspath = new StringBuilder();
             for (JavaJarDependency j : ideProject.dependencies.get()) {
                 if (javacClasspath.length() > 0) javacClasspath.append(File.pathSeparator);

--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Vscode.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/ide/Vscode.java
@@ -61,7 +61,7 @@ public enum Vscode implements Ide {
         settingsJson.addProperty("java.project.outputPath", "./.brachyura/vscodeout");
         JsonArray sourcePaths = new JsonArray();
         settingsJson.add("java.project.sourcePaths", sourcePaths);
-        for (Path path : ideProject.sourcePaths.values()) {
+        for (Path path : ideProject.sourcePaths) {
             sourcePaths.add(projectDir.relativize(path).toString()); // Why does this have to be relative?
         }
         JsonObject referencedLibraries = new JsonObject();

--- a/brachyura/src/main/java/io/github/coolcrabs/brachyura/project/java/BaseJavaProject.java
+++ b/brachyura/src/main/java/io/github/coolcrabs/brachyura/project/java/BaseJavaProject.java
@@ -65,7 +65,7 @@ public abstract class BaseJavaProject extends Project {
             for (JavaJarDependency dep : ideProject.dependencies.get()) {
                 compilation.addClasspath(dep.jar);
             }
-            for (Path srcDir : ideProject.sourcePaths.values()) {
+            for (Path srcDir : ideProject.sourcePaths) {
                 compilation.addSourceDir(srcDir);
             }
             Path outDir = Files.createTempDirectory("brachyurarun");


### PR DESCRIPTION
- Fix source folders being empty
  - Changed source handling to be project-local source folders instead of linked sources
- Fixed resources source folders not being added
- Reverted change that made source paths have names (since it was added with Eclipse support and it's not used anywhere else)
  - Can revert this if you want

Tested with Eclipse 2021-12 on Windows with the VanillaDisable mod and buildscript.